### PR TITLE
Support for Tasks (depends on #2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ L: mvp
 
 ```
 
-into CSV files ready for import into Tracker. 
+into CSV files ready for import into Tracker.
 
 ## Installation
 
@@ -64,7 +64,7 @@ Or just download the OS X binary from the GitHub releases page.
 
 ## Usage
 
-#### `prolific template`  
+#### `prolific template`
 
 Will generate a template `stories.prolific` file
 
@@ -74,6 +74,14 @@ Will emit a CSV version of the passed in prolific file.  You can use `>` to shov
 
 ```
 prolific stories.prolific > stories.csv
+```
+
+#### `STDIN`
+
+Prolific will also read content from standard input, which can be useful when combined with templates. For example:
+
+```
+erb stories.prolific.erb | prolific > stories.csv
 ```
 
 ## Syntax

--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ erb stories.prolific.erb | prolific > stories.csv
 Stories are separated by `\n---\n\n`.  Each story is a block made up of:
 
 - **Title**: The first line following the delimiter becomes the story title.  The story title must be on a single line.  The title is required.
-- **Story Type**(optional): The story title can be preceded by an optional `[X]` story type.  Legal values are `[FEATURE]` (the default), `[BUG]`, `[CHORE]`, and `[RELEASE]`.
-- **Description**(optional): Content immediately after the title is placed, verbatim, as the story's description.
-- **Labels**(optional): If the last line before `\n---\n\n` begins with `L:` Prolific will interpret the content following `L:` as comma-separated labels.
+- **Story Type** (optional): The story title can be preceded by an optional `[X]` story type.  Legal values are `[FEATURE]` (the default), `[BUG]`, `[CHORE]`, and `[RELEASE]`.
+- **Description** (optional): Content immediately after the title is placed, verbatim, as the story's description.
+- **Tasks** (optional): Content prefaced with `- [ ]` or `* [ ]` are converted into tasks (similar Github-flavored-Markdown checklists).
+- **Labels** (optional): If the last line before `\n---\n\n` begins with `L:` Prolific will interpret the content following `L:` as comma-separated labels.
 
 ## Import into Tracker
 

--- a/convert_stories.go
+++ b/convert_stories.go
@@ -9,12 +9,16 @@ import (
 	"os"
 )
 
-func ConvertAndEmitStories(file string) error {
+func ConvertAndEmitStoriesFromFile(file string) error {
 	content, err := ioutil.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("Couldn't load file: %s\n%s", file, err.Error())
 	}
 
+	return ConvertAndEmitStories(content)
+}
+
+func ConvertAndEmitStories(content []byte) error {
 	stories, errors := ExtractStories(content)
 
 	if len(errors) > 0 {

--- a/generate_template.go
+++ b/generate_template.go
@@ -42,6 +42,10 @@ L: mvp
 
 A metabolic endocrinide that the developrs will likely need to photoencapsulate.
 
+- [ ] task 1
+- [ ] task 2
+- [ ] task 3
+
 ---
 
 [RELEASE] Toaster MVP is Ready

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	}
 
 	fmt.Fprintf(os.Stderr, "Converting %s\n", os.Args[1])
-	err := ConvertAndEmitStories(os.Args[1])
+	err := ConvertAndEmitStoriesFromFile(os.Args[1])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Failed:", err.Error())
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -6,11 +6,23 @@ prolific: generate many tracker stories
 
 import (
 	"os"
+	"io/ioutil"
 
 	"fmt"
 )
 
 func main() {
+	content := readStdin()
+	if len(os.Args) == 1 && content != nil {
+		fmt.Fprintf(os.Stderr, "Converting STDIN\n")
+		err := ConvertAndEmitStories(content)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed:", err.Error())
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
 	if len(os.Args) != 2 {
 		PrintUsageAndExit()
 	}
@@ -37,4 +49,17 @@ func main() {
 	}
 
 	os.Exit(0)
+}
+
+func readStdin() []byte {
+	stat, err := os.Stdin.Stat()
+	if err != nil || (stat.Mode() & os.ModeCharDevice) != 0 {
+		return nil
+	}
+
+	stdin, err := ioutil.ReadAll(os.Stdin)
+	if err != nil {
+		return nil
+	}
+	return stdin
 }

--- a/prolific_test.go
+++ b/prolific_test.go
@@ -63,45 +63,49 @@ var _ = Describe("Prolific", func() {
 			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 			Ω(err).ShouldNot(HaveOccurred())
 			Eventually(session).Should(gexec.Exit(0))
-
-			cmd = exec.Command(prolific, "stories.prolific")
-			session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-			Ω(err).ShouldNot(HaveOccurred())
-			Eventually(session).Should(gexec.Exit(0))
 		})
 
-		It("should convert the passed-in prolific file", func() {
-			reader := csv.NewReader(bytes.NewReader(session.Out.Contents()))
-			records, err := reader.ReadAll()
-			Ω(err).ShouldNot(HaveOccurred())
+		Describe("reading from file", func() {
+			BeforeEach(func() {
+				cmd := exec.Command(prolific, "stories.prolific")
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+			})
 
-			By("emitting a header line")
-			Ω(records[0]).Should(Equal([]string{"Title", "Type", "Description", "Labels"}))
+			It("should convert the passed-in prolific file", func() {
+				reader := csv.NewReader(bytes.NewReader(session.Out.Contents()))
+				records, err := reader.ReadAll()
+				Ω(err).ShouldNot(HaveOccurred())
 
-			By("parsing all entries")
-			Ω(records).Should(HaveLen(7))
+				By("emitting a header line")
+				Ω(records[0]).Should(Equal([]string{"Title", "Type", "Description", "Labels"}))
 
-			var TITLE, TYPE, DESCRIPTION, LABELS = 0, 1, 2, 3
+				By("parsing all entries")
+				Ω(records).Should(HaveLen(7))
 
-			By("parsing all relevant fields")
-			Ω(records[1][TITLE]).Should(Equal("As a user I can toast a bagel"))
-			Ω(records[1][TYPE]).Should(Equal("feature"))
-			Ω(records[1][DESCRIPTION]).Should(Equal("When I insert a bagel into toaster and press the on button, I should get a toasted bagel"))
-			Ω(records[1][LABELS]).Should(Equal("mvp,toasting"))
+				var TITLE, TYPE, DESCRIPTION, LABELS = 0, 1, 2, 3
 
-			By("handling types correctly")
-			Ω(records[3][TYPE]).Should(Equal("feature"))
-			Ω(records[4][TYPE]).Should(Equal("bug"))
-			Ω(records[5][TYPE]).Should(Equal("chore"))
-			Ω(records[6][TYPE]).Should(Equal("release"))
+				By("parsing all relevant fields")
+				Ω(records[1][TITLE]).Should(Equal("As a user I can toast a bagel"))
+				Ω(records[1][TYPE]).Should(Equal("feature"))
+				Ω(records[1][DESCRIPTION]).Should(Equal("When I insert a bagel into toaster and press the on button, I should get a toasted bagel"))
+				Ω(records[1][LABELS]).Should(Equal("mvp,toasting"))
 
-			By("handling empty descriptions correctly")
-			Ω(records[4][DESCRIPTION]).Should(BeEmpty())
+				By("handling types correctly")
+				Ω(records[3][TYPE]).Should(Equal("feature"))
+				Ω(records[4][TYPE]).Should(Equal("bug"))
+				Ω(records[5][TYPE]).Should(Equal("chore"))
+				Ω(records[6][TYPE]).Should(Equal("release"))
 
-			By("handling labels correctly")
-			Ω(records[3][LABELS]).Should(Equal("mvp,clean-up"))
-			Ω(records[5][LABELS]).Should(BeEmpty())
-			Ω(records[6][LABELS]).Should(Equal("mvp"))
+				By("handling empty descriptions correctly")
+				Ω(records[4][DESCRIPTION]).Should(BeEmpty())
+
+				By("handling labels correctly")
+				Ω(records[3][LABELS]).Should(Equal("mvp,clean-up"))
+				Ω(records[5][LABELS]).Should(BeEmpty())
+				Ω(records[6][LABELS]).Should(Equal("mvp"))
+			})
 		})
 	})
 })

--- a/prolific_test.go
+++ b/prolific_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/onsi/gomega/gexec"
+	"github.com/onsi/gomega/gbytes"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,6 +19,28 @@ var _ = Describe("Prolific", func() {
 
 	AfterEach(func() {
 		os.Remove("stories.prolific")
+	})
+
+	Describe("prolific help", func() {
+		Context("given a 'help' argument", func() {
+			It("emits usage information", func() {
+				cmd := exec.Command(prolific, "help")
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+				Ω(session.Out).Should(gbytes.Say("Usage:"))
+			})
+		})
+
+		Context("given no argument", func() {
+			It("emits usage information", func() {
+				cmd := exec.Command(prolific)
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Ω(err).ShouldNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(1))
+				Ω(session.Out).Should(gbytes.Say("Usage:"))
+			})
+		})
 	})
 
 	Describe("prolific template", func() {

--- a/usage.go
+++ b/usage.go
@@ -9,19 +9,21 @@ func PrintUsageAndExit() {
 	fmt.Println(`prolific v2.0
 
 Usage:
-    prolific FILE
-        converts the passed in prolific file to a CSV printed to stdout
-        the CSV can be imported manually into Pivotal Tracker
+    prolific [FILE]
+        Converts the prolific file FILE to a CSV printed to stdout.
+        If FILE is not specified, content is read from STDIN.
 
-        prolific stories.prolific > stories.csv
+        The CSV can be imported manually into Pivotal Tracker, so:
 
-        is a useful one-liner
+            prolific stories.prolific > stories.csv
+
+        is a useful one-liner.
 
     prolific template
-        generates a sample stories.prolific
+        Generates a sample 'stories.prolific'.
 
     prolific help
-        you're looking at it!
+        You're looking at it!
 	
 Syntax:
     Stories are separated by the delimiter:

--- a/usage.go
+++ b/usage.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"fmt"
-	"os"
+    "fmt"
+    "os"
 )
 
 func PrintUsageAndExit() {
-	fmt.Println(`prolific v2.0
+    fmt.Println(`prolific v2.0
 
 Usage:
     prolific [FILE]
@@ -24,28 +24,33 @@ Usage:
 
     prolific help
         You're looking at it!
-	
+
 Syntax:
     Stories are separated by the delimiter:
 
-    ---
+        ---
 
     Each story is a block made up of:
 
-    [STORY_TYPE] TITLE
+        [STORY_TYPE] TITLE
 
-    DESCRIPTION
-    DESCRIPTION
-    DESCRIPTION
+        DESCRIPTION
+        DESCRIPTION
+        DESCRIPTION
 
-    L: LABEL 1, LABEL 2
+        - [ ] TASK 1
+        - [ ] TASK 2
+
+        L: LABEL 1, LABEL 2
 
     Of these, only TITLE is required and must be on a single line.
 
     [STORY_TYPE] may be omitted.  If present it must be one of:
-      [FEATURE]
-      [BUG]
-      [CHORE]
-      [RELEASE]`)
-	os.Exit(1)
+
+        [FEATURE]
+        [BUG]
+        [CHORE]
+        [RELEASE]
+`)
+    os.Exit(1)
 }


### PR DESCRIPTION
This adds support for Tasks, using the Github-flavored Markdown syntax for checklists.

It depends incidentally on PR #2, as the tests were constructed using using STDIN -- happy to rewrite the tests to remove that dependency if you like.

This implemention is the Simplest Thing Possible, but is a bit hacky in that it hardcodes eight TASK columns. If we have to push the content columns to anything more complex, it would be a good idea to introduce a StoryCollection struct, which would track stories, errors, and variable columns.

But for now, this should do.

I've obviously done some naïve things, and am still a relative Golang newb, so I welcome commentary and correction to my style and/or approach.
