### PR TITLE
Liberal separators

### DIFF
--- a/convert_stories.go
+++ b/convert_stories.go
@@ -52,7 +52,7 @@ var EmptyStoryError = errors.New("You have an empty story.")
 func ExtractStories(content string) ([]Story, int, []error) {
 	errors := []error{}
 
-	story_separator := regexp.MustCompile(`(?m)(\n\n|\A)---\n\s*`)
+	story_separator := regexp.MustCompile(`(?m)(\n\n|\A)---\s*\n\s*`)
 
 	parts := story_separator.Split(content, -1)
 

--- a/fixtures/liberal-separators.prolific
+++ b/fixtures/liberal-separators.prolific
@@ -1,0 +1,25 @@
+---
+
+Story 1
+
+This should be the first story, not the second.
+It's preceded only by a separator, not another story.
+
+---
+
+Story 2
+
+The dashes below this line indicate that this an H1.
+---
+
+... and so this should still be part of story 2.
+
+---
+Story 3
+
+This should be the final story, not the penultimate.
+It doesn't have whitespace between it and the preceding separator.
+It also is followed only by a separator, not another story.
+
+
+---

--- a/fixtures/liberal-separators.prolific
+++ b/fixtures/liberal-separators.prolific
@@ -5,7 +5,7 @@ Story 1
 This should be the first story, not the second.
 It's preceded only by a separator, not another story.
 
----
+---  
 
 Story 2
 
@@ -13,6 +13,8 @@ The dashes below this line indicate that this an H1.
 ---
 
 ... and so this should still be part of story 2.
+
+This story also has non-newline whitespace after its preceding separator.
 
 ---
 Story 3

--- a/fixtures/many-tasks.prolific
+++ b/fixtures/many-tasks.prolific
@@ -1,0 +1,13 @@
+As a user I can toast a bagel
+
+When I insert a bagel into toaster and press the on button, I should get a toasted bagel
+
+- [ ] task 1
+* [ ] task 2
+- [ ] task 3
+* [ ] task 4
+- [ ] task 5
+- [ ] task 6
+* [ ] task 7
+* [ ] task 8
+* [ ] task 9

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ func main() {
 	content := readStdin()
 	if len(os.Args) == 1 && content != nil {
 		fmt.Fprintf(os.Stderr, "Converting STDIN\n")
-		err := ConvertAndEmitStories(content)
+		err := ConvertAndEmitStories(string(content))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed:", err.Error())
 			os.Exit(1)

--- a/prolific_test.go
+++ b/prolific_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"path/filepath"
 
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
@@ -15,6 +15,10 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
+
+func fixturePath(filename string) (string) {
+	return filepath.Join("fixtures", filename + ".prolific")
+}
 
 var _ = Describe("Prolific", func() {
 	var session *gexec.Session
@@ -155,38 +159,10 @@ var _ = Describe("Prolific", func() {
 		})
 
 		Describe("tasks", func() {
-			var cmd *exec.Cmd
-			var stdin io.WriteCloser
-
-			BeforeEach(func() {
-				cmd = exec.Command(prolific)
-				stdin, err = cmd.StdinPipe()
-				Ω(err).ShouldNot(HaveOccurred())
-			})
-
 			Context("with many tasks", func() {
-				const story = `As a user I can toast a bagel
-
-When I insert a bagel into toaster and press the on button, I should get a toasted bagel
-
-- [ ] task 1
-* [ ] task 2
-- [ ] task 3
-* [ ] task 4
-- [ ] task 5
-- [ ] task 6
-* [ ] task 7
-* [ ] task 8
-* [ ] task 9
-`
 				It("populates all task columns", func() {
-					_, err = stdin.Write([]byte(story))
-					Ω(err).ShouldNot(HaveOccurred())
-
+					cmd := exec.Command(prolific, fixturePath("many-tasks"))
 					session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-					Ω(err).ShouldNot(HaveOccurred())
-
-					err = stdin.Close()
 					Ω(err).ShouldNot(HaveOccurred())
 					Eventually(session).Should(gexec.Exit(0))
 

--- a/prolific_test.go
+++ b/prolific_test.go
@@ -21,6 +21,7 @@ func fixturePath(filename string) (string) {
 }
 
 var _ = Describe("Prolific", func() {
+	var TITLE, TYPE, DESCRIPTION, LABELS, TASK1 = 0, 1, 2, 3, 4
 	var session *gexec.Session
 	var err error
 
@@ -90,8 +91,6 @@ var _ = Describe("Prolific", func() {
 
 				By("parsing all entries")
 				Ω(records).Should(HaveLen(7))
-
-				var TITLE, TYPE, DESCRIPTION, LABELS, TASK1 = 0, 1, 2, 3, 4
 
 				By("parsing all relevant fields")
 				Ω(records[1][TITLE]).Should(Equal("As a user I can toast a bagel"))
@@ -178,6 +177,24 @@ var _ = Describe("Prolific", func() {
 						Ω(records[1][TASK1+j]).Should(Equal(fmt.Sprintf("task %d", j+1)))
 					}
 				})
+			})
+		})
+
+		Describe("liberal separator-handling", func() {
+			It("handles variations on whitespace around record separators", func() {
+				cmd := exec.Command(prolific, fixturePath("liberal-separators"))
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(session).Should(gexec.Exit(0))
+
+				reader := csv.NewReader(bytes.NewReader(session.Out.Contents()))
+				records, err := reader.ReadAll()
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(records).To(HaveLen(4))
+				Expect(records[1][TITLE]).To(MatchRegexp("Story 1"))
+				Expect(records[2][TITLE]).To(MatchRegexp("Story 2"))
+				Expect(records[3][TITLE]).To(MatchRegexp("Story 3"))
 			})
 		})
 	})


### PR DESCRIPTION
When detecting story separators, be more flexible about the whitespace surrounding the "^---\n".

In particular, if you're using HAML to generate your markdown, prolific will now deal with the fact that HAML output has whitespace trimmed in odd ways.
