### PR TITLE
Add support for line break markdown by changing story seperator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When I insert a bagel into toaster and press the on button, I should get a toast
 
 L: mvp, toasting
 
----
+----
 
 As a user I can set the desired color of my bagel
 
@@ -25,7 +25,7 @@ Pressing the on button gives me toast of the appropriate color.
 
 L: mvp, toasting
 
----
+----
 
 As a user I can clean my bagel toaster
 
@@ -33,13 +33,13 @@ I should be able to pull out a tray and clean up the crumbs.
 
 L: mvp, clean-up
 
----
+----
 
 [BUG] Every third time I use it, the toaster jams
 
 L: mvp
 
----
+----
 
 [CHORE] Reticulate the Toaster's turboencabulator
 
@@ -49,7 +49,7 @@ A metabolic endocrinide that the developrs will likely need to photoencapsulate.
 - [ ] Masticulate the retracto-mandible
 - [ ] Effervesce all enteropolycarbides
 
----
+----
 
 [RELEASE] Toaster MVP is Ready
 
@@ -90,13 +90,13 @@ erb stories.prolific.erb | prolific > stories.csv
 
 ## Syntax
 
-Stories are separated by `\n---\n\n`.  Each story is a block made up of:
+Stories are separated by `\n----\n\n`.  Each story is a block made up of:
 
 - **Title**: The first line following the delimiter becomes the story title.  The story title must be on a single line.  The title is required.
 - **Story Type** (optional): The story title can be preceded by an optional `[X]` story type.  Legal values are `[FEATURE]` (the default), `[BUG]`, `[CHORE]`, and `[RELEASE]`.
 - **Description** (optional): Content immediately after the title is placed, verbatim, as the story's description.
 - **Tasks** (optional): Content prefaced with `- [ ]` or `* [ ]` are converted into tasks (similar Github-flavored-Markdown checklists).
-- **Labels** (optional): If the last line before `\n---\n\n` begins with `L:` Prolific will interpret the content following `L:` as comma-separated labels.
+- **Labels** (optional): If the last line before `\n----\n\n` begins with `L:` Prolific will interpret the content following `L:` as comma-separated labels.
 
 ## Import into Tracker
 

--- a/convert_stories.go
+++ b/convert_stories.go
@@ -52,7 +52,7 @@ var EmptyStoryError = errors.New("You have an empty story.")
 func ExtractStories(content string) ([]Story, int, []error) {
 	errors := []error{}
 
-	story_separator := regexp.MustCompile(`(?m)(\n\n|\A)---\s*\n\s*`)
+	story_separator := regexp.MustCompile(`(?m)(\n\n|\A)----\s*\n\s*`)
 
 	parts := story_separator.Split(content, -1)
 

--- a/fixtures/liberal-separators.prolific
+++ b/fixtures/liberal-separators.prolific
@@ -1,22 +1,24 @@
----
+----
 
 Story 1
 
 This should be the first story, not the second.
 It's preceded only by a separator, not another story.
 
----  
+----
 
 Story 2
 
 The dashes below this line indicate that this an H1.
----
+----
 
 ... and so this should still be part of story 2.
 
+---
+
 This story also has non-newline whitespace after its preceding separator.
 
----
+----
 Story 3
 
 This should be the final story, not the penultimate.
@@ -24,4 +26,4 @@ It doesn't have whitespace between it and the preceding separator.
 It also is followed only by a separator, not another story.
 
 
----
+----

--- a/generate_template.go
+++ b/generate_template.go
@@ -8,7 +8,7 @@ When I insert a bagel into toaster and press the on button, I should get a toast
 
 L: mvp, toasting
 
----
+----
 
 As a user I can set the desired color of my bagel
 
@@ -22,7 +22,7 @@ Pressing the on button gives me toast of the appropriate color.
 
 L: mvp, toasting
 
----
+----
 
 As a user I can clean my bagel toaster
 
@@ -30,13 +30,13 @@ I should be able to pull out a tray and clean up the crumbs.
 
 L: mvp, clean-up
 
----
+----
 
 [BUG] Every third time I use it, the toaster jams
 
 L: mvp
 
----
+----
 
 [CHORE] Reticulate the Toaster's turboencabulator
 
@@ -46,7 +46,7 @@ A metabolic endocrinide that the developrs will likely need to photoencapsulate.
 - [ ] Masticulate the retracto-mandible
 - [ ] Effervesce all enteropolycarbides
 
----
+----
 
 [RELEASE] Toaster MVP is Ready
 


### PR DESCRIPTION
As the current story split was ---, it meant that the line break markdown was not useable.

I have updated the story splitter to be ----, which I believe does not have any markdown meaning.
